### PR TITLE
fix: do not crash when a span starts under an already completed caller

### DIFF
--- a/src/protocols/http-interceptor.int-spec.ts
+++ b/src/protocols/http-interceptor.int-spec.ts
@@ -1,0 +1,93 @@
+import {
+  CallHandler,
+  Controller,
+  ExecutionContext,
+  Get,
+  Injectable,
+  Module,
+  NestInterceptor,
+} from "@nestjs/common";
+import { APP_INTERCEPTOR, NestFactory } from "@nestjs/core";
+import { NestExpressApplication } from "@nestjs/platform-express";
+import { Observable } from "rxjs";
+import request from "supertest";
+import { createObserveModule } from "../observe.module.js";
+import {
+  CollectedSnapshots,
+  collectSnapshots,
+  testObserveOptions,
+  waitForSnapshot,
+} from "../testing/observe-harness.js";
+
+const { ObserveModule, ObserveInstrument } = createObserveModule();
+
+/**
+ * The shape every pass-through interceptor has - `@sentry/nestjs`'s
+ * `SentryTracingInterceptor` included: `intercept()` returns the downstream
+ * Observable synchronously, so the span the instrumentation opens for it
+ * closes before the handler runs.
+ */
+@Injectable()
+class PassThroughInterceptor implements NestInterceptor {
+  intercept(
+    _context: ExecutionContext,
+    next: CallHandler,
+  ): Observable<unknown> {
+    return next.handle();
+  }
+}
+
+@Controller()
+class OrdersController {
+  @Get("orders")
+  findAll() {
+    return [{ id: 1 }];
+  }
+}
+
+@Module({
+  imports: [ObserveModule.forRoot(testObserveOptions())],
+  controllers: [OrdersController],
+  providers: [{ provide: APP_INTERCEPTOR, useClass: PassThroughInterceptor }],
+})
+class InterceptorTestModule {}
+
+/**
+ * Nest binds the stage after an interceptor to the async context in which
+ * `next.handle()` was called (`AsyncResource.bind` in its interceptors
+ * consumer), so the handler inherits the interceptor's span as its caller -
+ * a span that has already completed by the time the handler starts.
+ */
+describe("ObserveModule: HTTP collection with a global interceptor", () => {
+  let app: NestExpressApplication;
+  let collected: CollectedSnapshots;
+
+  beforeAll(async () => {
+    app = await NestFactory.create<NestExpressApplication>(
+      InterceptorTestModule,
+      { instrument: ObserveInstrument, logger: false },
+    );
+    collected = collectSnapshots(app);
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app?.close();
+  });
+
+  beforeEach(() => collected.clear());
+
+  it("serves the request and records the handler span at the root", async () => {
+    await request(app.getHttpServer()).get("/orders").expect(200);
+
+    const snapshot = await waitForSnapshot(
+      collected,
+      (item) => item.operationId === "/orders",
+    );
+
+    expect(snapshot.attributes?.statusCode).toBe(200);
+    expect(snapshot.traces.map((node) => node.methodKey)).toEqual(
+      expect.arrayContaining(["intercept", "findAll"]),
+    );
+  });
+});

--- a/src/services/operation-trace.registry.spec.ts
+++ b/src/services/operation-trace.registry.spec.ts
@@ -187,6 +187,39 @@ describe("OperationTraceRegistry", () => {
       expect(root.children?.map((node) => node.methodKey)).toEqual(["child"]);
     });
 
+    it("puts a span whose caller already completed at the root instead of throwing", async () => {
+      startRequest("t6b");
+      const caller = registry.internalStartTraceStep(
+        "t6b",
+        "Interceptor",
+        "intercept",
+        undefined,
+      );
+      // An interceptor's `intercept()` returns its Observable synchronously, so
+      // its span closes - and, having no children yet, loses its `children`
+      // array - before the handler that Nest bound to its async context runs.
+      registry.internalEndTraceStep(
+        "t6b",
+        caller,
+        "Interceptor",
+        "intercept",
+        caller,
+      );
+
+      let late: string | undefined;
+      expect(() => {
+        late = registry.internalStartTraceStep("t6b", "Ctrl", "handle", caller);
+      }).not.toThrow();
+      registry.internalEndTraceStep("t6b", late, "Ctrl", "handle", late);
+      registry.endTrace("t6b");
+
+      const snapshot = await registry.pluckSnapshot("t6b");
+      expect(snapshot!.traces.map((node) => node.methodKey)).toEqual([
+        "intercept",
+        "handle",
+      ]);
+    });
+
     it("uses the span id as the caller id it registers under", async () => {
       startRequest("t7");
       const spanId = registry.internalStartTraceStep(

--- a/src/services/operation-trace.registry.ts
+++ b/src/services/operation-trace.registry.ts
@@ -334,13 +334,21 @@ export class OperationTraceRegistry {
       spanId: newNodeId,
     };
 
-    let refsByCaller = this.callerIdsByTraceId.get(traceId)!;
-    if (callerId) {
-      const caller = refsByCaller.get(callerId)!;
+    let refsByCaller = this.callerIdsByTraceId.get(traceId);
+    // A caller that has already completed has had its scratch fields stripped
+    // (`type`, and `children` when it had none), so there is nothing left to
+    // nest under. That happens whenever a callee outlives its caller - most
+    // commonly a handler that Nest bound (`AsyncResource.bind` in its
+    // interceptors consumer) to the async context of an interceptor whose
+    // `intercept()` returned synchronously. Fall back to the root rather than
+    // throw into the request: the mirror case, a step ending after its caller
+    // did, is already tolerated in `internalEndTraceStep`.
+    const caller = callerId ? refsByCaller?.get(callerId) : undefined;
+    if (caller?.type === "start") {
       caller.children.push(newNode);
       newNode.parent = caller;
     } else {
-      // No caller means insert trace at the root level
+      // No (live) caller means insert trace at the root level
       snapshot.traces.push(newNode);
     }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) — no docs impact


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

With `ObserveModule` registered and **any global interceptor** in the app (for example `SentryModule.forRoot()` from `@sentry/nestjs`, which registers `SentryTracingInterceptor` as `APP_INTERCEPTOR`), **every request that reaches a controller handler answers 500**:

```
TypeError: Cannot read properties of undefined (reading 'push')
    at OperationTraceRegistry.internalStartTraceStep (operation-trace.registry.js:232)
    at <Controller>.<handler>  (create-instance-decorator.instrument.js)
```

Why:

1. `internalStartTraceStep` does `caller.children.push(newNode)` whenever a `callerId` is present, without checking that the caller is still open (`refsByCaller.get(callerId)!`).
2. `internalEndTraceStep` strips the scratch fields of a completed span — `type`, and `children` when the span had none.
3. Nest binds the stage after `next.handle()` to the async context it was called in (`AsyncResource.bind` in `InterceptorsConsumer`), so the handler inherits the interceptor's span id as its `CALLER_METADATA_KEY`. A pass-through `intercept()` returns its Observable synchronously, so that span has already completed — and lost its `children` array — by the time the handler's span opens under it.

Reproduced on `0.1.2` with Node 22 and a minimal app (global interceptor that just returns `next.handle()` + one `@Get()`); the new integration test in this PR is that app, and it fails on `master` with `expected 200 "OK", got 500 "Internal Server Error"`.

Issue Number: N/A (issues are disabled on this repository)


## What is the new behavior?

A span whose caller has already completed is attached at the root of the trace instead of throwing — the same tolerance `internalEndTraceStep` already has for a step that outlives its caller. Requests through a global interceptor succeed again and the handler span is still recorded.

Covered by:
- a unit test in `operation-trace.registry.spec.ts` (start → end a caller, then start a step under it: no throw, both spans at the root);
- an integration test `http-interceptor.int-spec.ts` that boots a real app with a global pass-through interceptor and expects `200` plus the `intercept` and handler spans in the snapshot.

`npm test` (400) and `npm run test:int` (41) pass locally.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information

A handler span now lands at the root next to the (already closed) interceptor span rather than nested under it. Nesting it under a span whose duration is already final would produce a child that outlives its parent, so the root seemed the honest place; happy to change that if you prefer a different shape.
