### PR TITLE
fix: load @nestjs/microservices and @nestjs/bullmq only when present

### DIFF
--- a/src/protocols/queue-observe-agent.service.spec.ts
+++ b/src/protocols/queue-observe-agent.service.spec.ts
@@ -1,0 +1,48 @@
+import { ProcessorDecoratorService } from "@nestjs/bullmq/dist/instrument/processor-decorator.service.js";
+import { AsyncLocalStorage } from "async_hooks";
+import { QueueObserveAgentService } from "./queue-observe-agent.service.js";
+
+/**
+ * `@nestjs/bullmq` is an optional peer: the agent must patch the processor
+ * decorator when it is installed and stay inert - not crash the module - when
+ * it is not. The loader is stubbed for the latter; the package is always
+ * present in this repository's own dependencies.
+ */
+describe("QueueObserveAgentService", () => {
+  const prototype = ProcessorDecoratorService.prototype as {
+    decorate?: unknown;
+  };
+  const originalDecorate = prototype.decorate;
+
+  const createAgent = () =>
+    new QueueObserveAgentService(
+      {} as never,
+      { traceIdKey: "traceId" } as never,
+      {} as never,
+      new AsyncLocalStorage<Map<string, any>>(),
+    );
+
+  afterEach(() => {
+    prototype.decorate = originalDecorate;
+    vi.restoreAllMocks();
+  });
+
+  it("patches the processor decorator when @nestjs/bullmq is installed", () => {
+    createAgent();
+
+    expect(prototype.decorate).toEqual(expect.any(Function));
+    expect(prototype.decorate).not.toBe(originalDecorate);
+  });
+
+  it("stays inert when @nestjs/bullmq is not installed", () => {
+    vi.spyOn(
+      QueueObserveAgentService.prototype as unknown as {
+        loadProcessorDecoratorService: () => unknown;
+      },
+      "loadProcessorDecoratorService",
+    ).mockReturnValue(undefined);
+
+    expect(() => createAgent()).not.toThrow();
+    expect(prototype.decorate).toBe(originalDecorate);
+  });
+});

--- a/src/protocols/queue-observe-agent.service.ts
+++ b/src/protocols/queue-observe-agent.service.ts
@@ -1,8 +1,8 @@
-import { ProcessorDecoratorService } from "@nestjs/bullmq/dist/instrument/processor-decorator.service.js";
 import { Inject, Injectable, Logger } from "@nestjs/common";
 import { AsyncLocalStorage } from "async_hooks";
-import { Job, Processor } from "bullmq";
+import type { Job, Processor } from "bullmq";
 import { randomUUID } from "crypto";
+import { createRequire } from "module";
 import { ObserveAgentSharedBuffer } from "../agent/observe-agent.shared-buffer.js";
 import {
   JobSnapshot,
@@ -11,6 +11,15 @@ import {
 import { OperationTraceRegistry } from "../services/operation-trace.registry.js";
 import { KeyOf } from "../types/key-of.type.js";
 import { OBSERVE_OPTIONS } from "../observe.constants.js";
+
+/** The `ProcessorDecoratorService` surface this service patches, structurally typed. */
+interface ProcessorDecoratorServiceLike {
+  prototype?: {
+    decorate?: (
+      processor: Processor<unknown, unknown>,
+    ) => (job: Job) => unknown;
+  };
+}
 
 @Injectable()
 export class QueueObserveAgentService<Store extends Record<string, unknown>> {
@@ -67,7 +76,44 @@ export class QueueObserveAgentService<Store extends Record<string, unknown>> {
     return metadata;
   }
 
+  /**
+   * Loads `@nestjs/bullmq`'s processor decorator without a static import, so a
+   * service that runs no queue need not install the package. Synchronous on
+   * purpose: the prototype is patched from the constructor, strictly before
+   * any processor is decorated. `@nestjs/bullmq` ships CommonJS, so `require`
+   * can load it.
+   *
+   * Returns `undefined` when the package is not installed and `null` when it
+   * is, but too old to expose the decorator service.
+   */
+  private loadProcessorDecoratorService():
+    | ProcessorDecoratorServiceLike
+    | null
+    | undefined {
+    const require = createRequire(import.meta.url);
+    try {
+      require.resolve("@nestjs/bullmq");
+    } catch {
+      return undefined;
+    }
+    try {
+      const { ProcessorDecoratorService } =
+        require("@nestjs/bullmq/dist/instrument/processor-decorator.service.js") as {
+          ProcessorDecoratorService?: ProcessorDecoratorServiceLike;
+        };
+      return ProcessorDecoratorService ?? null;
+    } catch {
+      return null;
+    }
+  }
+
   private patchDecorate() {
+    const ProcessorDecoratorService = this.loadProcessorDecoratorService();
+    if (ProcessorDecoratorService === undefined) {
+      // The @nestjs/bullmq package is an optional peer. No queue means no
+      // processor to wrap, and that is not a misconfiguration.
+      return;
+    }
     if (!ProcessorDecoratorService?.prototype) {
       this.logger.warn(
         "ProcessorDecoratorService is not available. Please, update to the latest version of @nestjs/bullmq. Skipping patching.",

--- a/src/protocols/rpc-observe-agent.service.spec.ts
+++ b/src/protocols/rpc-observe-agent.service.spec.ts
@@ -1,0 +1,50 @@
+import { AsyncLocalStorage } from "async_hooks";
+import { RpcObserveAgentService } from "./rpc-observe-agent.service.js";
+
+/**
+ * `@nestjs/microservices` is an optional peer: the agent must hook RPC
+ * targets when it is installed and stay inert - not crash the module - when
+ * it is not. The loader is stubbed for the latter; the package is always
+ * present in this repository's own dependencies.
+ */
+describe("RpcObserveAgentService", () => {
+  const options = { traceIdKey: "traceId" } as never;
+
+  const createAgent = (subscribe: (...args: unknown[]) => unknown) =>
+    new RpcObserveAgentService(
+      new AsyncLocalStorage<Map<string, any>>(),
+      options,
+      { getRpcTargetRegistry: () => ({ subscribe }) } as never,
+      {} as never,
+      {} as never,
+      {} as never,
+    );
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("subscribes to the RPC target registry when @nestjs/microservices is installed", () => {
+    const subscribe = vi.fn(() => ({ unsubscribe: vi.fn() }));
+    const agent = createAgent(subscribe);
+
+    agent.onModuleInit();
+
+    expect(subscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays inert when @nestjs/microservices is not installed", () => {
+    vi.spyOn(
+      RpcObserveAgentService.prototype as unknown as {
+        loadMicroservices: () => unknown;
+      },
+      "loadMicroservices",
+    ).mockReturnValue(undefined);
+    const subscribe = vi.fn();
+    const agent = createAgent(subscribe);
+
+    expect(() => agent.onModuleInit()).not.toThrow();
+    expect(subscribe).not.toHaveBeenCalled();
+    expect(() => agent.onModuleDestroy()).not.toThrow();
+  });
+});

--- a/src/protocols/rpc-observe-agent.service.ts
+++ b/src/protocols/rpc-observe-agent.service.ts
@@ -5,18 +5,9 @@ import {
   OnModuleInit,
 } from "@nestjs/common";
 import { ModulesContainer } from "@nestjs/core";
-import {
-  BaseRpcContext,
-  KafkaContext,
-  MqttContext,
-  NatsContext,
-  RedisContext,
-  RmqContext,
-  Server,
-  TcpContext,
-  Transport,
-} from "@nestjs/microservices";
+import type { BaseRpcContext, Server, Transport } from "@nestjs/microservices";
 import { AsyncLocalStorage } from "async_hooks";
+import { createRequire } from "module";
 import { Subscription } from "rxjs";
 import { ObserveAgentSharedBuffer } from "../agent/observe-agent.shared-buffer.js";
 import { RequestSnapshot } from "../interfaces/index.js";
@@ -25,6 +16,22 @@ import { OperationTraceRegistry } from "../services/operation-trace.registry.js"
 import { TraceSamplerService } from "../services/trace-sampler.service.js";
 import { KeyOf } from "../types/key-of.type.js";
 import { OBSERVE_OPTIONS } from "../observe.constants.js";
+
+/**
+ * The `@nestjs/microservices` surface this agent reads, loaded on demand so
+ * the package stays an optional peer: the transport enum, and the context
+ * classes the operation id is read from.
+ */
+type Microservices = Pick<
+  typeof import("@nestjs/microservices"),
+  | "Transport"
+  | "KafkaContext"
+  | "MqttContext"
+  | "NatsContext"
+  | "RedisContext"
+  | "RmqContext"
+  | "TcpContext"
+>;
 
 interface GrpcCall<TRequest = any, TMetadata = any> {
   request: TRequest;
@@ -37,6 +44,12 @@ export class RpcObserveAgentService<Store extends Record<string, unknown>>
   implements OnModuleInit, OnModuleDestroy
 {
   private rpcTargetAddedSubscription: Subscription | undefined;
+  /**
+   * Assigned in `onModuleInit`. Every use below is reached only through the
+   * hooks registered there, after a successful load - a service without the
+   * package has no RPC target to hook.
+   */
+  private microservices: Microservices | undefined;
 
   constructor(
     private readonly asyncLocalStorage: AsyncLocalStorage<
@@ -51,6 +64,10 @@ export class RpcObserveAgentService<Store extends Record<string, unknown>>
   ) {}
 
   onModuleInit() {
+    this.microservices = this.loadMicroservices();
+    if (!this.microservices) {
+      return;
+    }
     this.rpcTargetAddedSubscription = this.modulesContainer
       .getRpcTargetRegistry?.<Server>()
       .subscribe((target) => this.registerRpcHooks(target));
@@ -62,6 +79,25 @@ export class RpcObserveAgentService<Store extends Record<string, unknown>>
     }
   }
 
+  /**
+   * Loads `@nestjs/microservices` without a static import, so a service that
+   * exposes no microservice need not install the package. Synchronous on
+   * purpose, for the same reason as the schedule agent's loader: the target
+   * registry is subscribed from `onModuleInit`, and a dynamic `import()` would
+   * resolve after a target may already have been announced. The package ships
+   * CommonJS, so `require` can load it.
+   */
+  private loadMicroservices(): Microservices | undefined {
+    try {
+      const require = createRequire(import.meta.url);
+      return require("@nestjs/microservices") as Microservices;
+    } catch {
+      // The @nestjs/microservices package is an optional peer. No microservice
+      // means no RPC target to hook, and that is not a misconfiguration.
+      return undefined;
+    }
+  }
+
   registerRpcHooks(target: Server) {
     target.setOnProcessingStartHook(
       (
@@ -69,7 +105,7 @@ export class RpcObserveAgentService<Store extends Record<string, unknown>>
         ctx: unknown,
         done: () => Promise<any>,
       ) => {
-        if (transportId === Transport.GRPC) {
+        if (transportId === this.microservices!.Transport.GRPC) {
           this.startGrpcRequestTracing(transportId, ctx as GrpcCall, done);
           return;
         }
@@ -97,7 +133,7 @@ export class RpcObserveAgentService<Store extends Record<string, unknown>>
   private toProtocolName(transportId: Transport | symbol): string {
     return typeof transportId === "symbol"
       ? transportId.description ?? "custom"
-      : Transport[transportId];
+      : this.microservices!.Transport[transportId];
   }
 
   startRpcRequestTracing(
@@ -198,7 +234,7 @@ export class RpcObserveAgentService<Store extends Record<string, unknown>>
     }
     setTimeout(async () => {
       let userId: string | undefined;
-      if (transportId === Transport.GRPC) {
+      if (transportId === this.microservices!.Transport.GRPC) {
         if (this.options.grpc?.getUserId) {
           userId = this.options.grpc?.getUserId?.(ctx as GrpcCall);
         }
@@ -225,6 +261,14 @@ export class RpcObserveAgentService<Store extends Record<string, unknown>>
   }
 
   private getOperationIdFromContext(ctx: BaseRpcContext): string {
+    const {
+      KafkaContext,
+      MqttContext,
+      NatsContext,
+      RedisContext,
+      RmqContext,
+      TcpContext,
+    } = this.microservices!;
     switch (true) {
       case ctx instanceof KafkaContext:
       case ctx instanceof MqttContext:


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features) — the README already describes the intended behaviour; this PR makes the code match it


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

The README says protocol integrations "are only loaded when you use them, and their packages are optional peers", and `peerDependenciesMeta` marks `@nestjs/microservices` and `@nestjs/bullmq` optional. The GraphQL and schedule agents honour that (`await import()` / `createRequire` behind a `try`). The RPC and queue agents do not — they import the packages at the top of the file:

```js
// dist/protocols/rpc-observe-agent.service.js
import { KafkaContext, MqttContext, ..., Transport } from "@nestjs/microservices";
// dist/protocols/queue-observe-agent.service.js
import { ProcessorDecoratorService } from "@nestjs/bullmq/dist/instrument/processor-decorator.service.js";
```

Under ESM those resolve the moment the module graph is loaded, so an HTTP-only app gets this from `require("@nestjs/observe")` / `import "@nestjs/observe"`:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@nestjs/bullmq' imported from
  .../node_modules/@nestjs/observe/dist/protocols/queue-observe-agent.service.js
```

(and `@nestjs/microservices` next, once bullmq is added). The only way to boot 0.1.2 without a queue or a microservice is to install both packages anyway.

Reproduction: pack the package, `npm install` the tarball into an empty project next to only `@nestjs/common@11 @nestjs/core@11 reflect-metadata rxjs`, then `node -r reflect-metadata -e 'require("@nestjs/observe")'`. Note the CI step "require(esm) from CommonJS" installs from `$GITHUB_WORKSPACE`, which npm links rather than copies, so resolution falls through to the repository's own `node_modules` and the step cannot see this.

Issue Number: N/A (issues are disabled on this repository)


## What is the new behavior?

Both agents load their peer the way the schedule agent already loads `@nestjs/schedule`: a synchronous `createRequire` inside the agent, with absence treated as the normal case rather than a misconfiguration.

- **RPC**: the package is loaded in `onModuleInit`; when it is missing the agent does not subscribe to the RPC target registry at all (without the package there is no `Server` to hook). `Transport` and the context classes used for `instanceof` come from the loaded module. Types go through `import type` / `typeof import("@nestjs/microservices")`, which emit nothing.
- **Queue**: the processor decorator is loaded right before it is patched. Not installed → nothing to patch; installed but too old to expose `ProcessorDecoratorService` → the existing warning, unchanged.

Tests: a unit spec per agent covering "installed → hooks/patches" and "not installed → inert, no throw". The existing TCP and gRPC integration suites exercise the loaded path end to end.

With the packed tarball installed next to only `@nestjs/common`, `@nestjs/core`, `reflect-metadata` and `rxjs`, `require("@nestjs/observe")` now returns `createObserveModule()` as expected; `0.1.2` fails in that same setup with the error above. `npm test` (403), `npm run test:int` (40), `npm run lint` and `npm run build` pass locally.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information

Independent of #2 (different files, different cause); either can land first.
