### PR TITLE
fix: keep the original method arity on the wrapper

### DIFF
--- a/src/instrument/create-instance-decorator.instrument.spec.ts
+++ b/src/instrument/create-instance-decorator.instrument.spec.ts
@@ -71,6 +71,10 @@ describe("createInstanceDecorator", () => {
       async findAsync() {
         return "async-ok";
       }
+
+      store(_req: unknown, _meta: unknown, _done: unknown) {
+        return "stored";
+      }
     }
 
     it("records a trace step named after the class and method", () => {
@@ -193,6 +197,14 @@ describe("createInstanceDecorator", () => {
       const service = decorate(new UserService()) as UserService;
 
       expect(service.findAll.name).toEqual("findAll");
+    });
+
+    it("keeps the original arity on the returned wrapper", () => {
+      // Libraries such as passport-oauth2 read `fn.length` to choose which
+      // arguments to pass, thus a wrapper reporting 0 changes the call.
+      const service = decorate(new UserService()) as UserService;
+
+      expect(service.store.length).toEqual(3);
     });
 
     it("forwards arguments and preserves `this`", () => {

--- a/src/instrument/create-instance-decorator.instrument.ts
+++ b/src/instrument/create-instance-decorator.instrument.ts
@@ -320,6 +320,10 @@ export function createInstanceDecorator<T extends Record<string, unknown>>(
           value: originalMethod.name,
           configurable: true,
         });
+        Object.defineProperty(boundFn, "length", {
+          value: originalMethod.length,
+          configurable: true,
+        });
         const metadataKeys = Reflect.getMetadataKeys(originalMethod);
         for (const key of metadataKeys) {
           const metadata = Reflect.getMetadata(key, originalMethod);


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: nestjs/nest#17642

The instrumentation wrapper reports `length === 0` for every method, whatever
the original declares.

`bind()` drops `name` and `length`. The code restores `name`, and the comment
above it says it restores both:

```ts
// `bind` renames the function to "bound <name>" and drops metadata;
// restore both so the wrapper stays indistinguishable from the original
// to anything reflecting over it (DI, decorators, arity checks).
Object.defineProperty(boundFn, "name", {
  value: originalMethod.name,
  configurable: true,
});
```

"arity checks" is in that comment, but `length` is never restored.

A library that dispatches on `fn.length` then reads `0` and passes the wrong
arguments. `passport-oauth2` reads `this._stateStore.store.length` to choose
between `store(req, meta, done)` and `store(req, done)`. With an instrumented
store it takes the second form, and the callback is `undefined`.

```js
class MyStateStore {
  store(req, meta, callback) { callback(null, "ok"); }
}

const instrumented = ObserveInstrument.instanceDecorator(new MyStateStore());

instance.store.length;      // 3
instrumented.store.length;  // 0
```

## What is the new behavior?

`length` is restored next to `name`, the same way. The wrapper reports the
arity of the original, thus the calling library picks the right form.

```
                         before   after
store.length                  0       3
```

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

The wrapper now reports what the original method reports.

## Other information

`Function.prototype.length` is `configurable: true`, thus `defineProperty` is
enough — the same route `name` already takes.

The new test fails without the fix with `expected +0 to deeply equal 3`.
